### PR TITLE
Misc fixes to get running on my machine

### DIFF
--- a/LCC_matrices.py
+++ b/LCC_matrices.py
@@ -219,7 +219,7 @@ def createMatrices(
         mode = 'a'
         if not os.path.isfile(qaqc_path):
             mode = 'w'
-        with pd.ExcelWriter(qaqc_path, mode=mode) as writer:
+        with pd.ExcelWriter(qaqc_path, mode=mode, engine='openpyxl') as writer:
             for i in range(len(matrices)):
                 sheet = f"{years[i]}-{years[i+1]}-{version}" 
                 matrices[i].to_excel(writer, sheet_name=sheet, index=True)
@@ -343,7 +343,7 @@ def write_static_totals(df22:pd.DataFrame, df24:pd.DataFrame, qaqc_path:str):
     all_totals = all_totals[columns]
 
     # write totals
-    with pd.ExcelWriter(qaqc_path, mode='a') as writer:
+    with pd.ExcelWriter(qaqc_path, mode='a', engine='openpyxl') as writer:
         sheet = f"LC_Totals" 
         all_totals.to_excel(writer, sheet_name=sheet, index=True)
 
@@ -400,7 +400,7 @@ def difference_matrices(
 
     # write results
     sheet = f"{year1}-{year2}_{versions[0]}-{versions[1]}" 
-    with pd.ExcelWriter(qaqc_path, mode='a') as writer:
+    with pd.ExcelWriter(qaqc_path, mode='a', engine='openpyxl') as writer:
         df1.to_excel(writer, sheet_name=sheet, index=True)
 
     # add style

--- a/QA_LCC.py
+++ b/QA_LCC.py
@@ -108,7 +108,7 @@ if __name__=="__main__":
     lcc_lookup.drop('class', axis=1, inplace=True)
 
     # iterate cofips
-    for cf in cfs:
+    for i, cf in enumerate(cfs):
         logger.info(f"Starting {cf}")
 
         # get mapped years for county
@@ -116,7 +116,9 @@ if __name__=="__main__":
         output_path = f"{config['folders']['qaqc']}/{cf}_LCC_QA.xlsx"
 
         # replace transitions with abbreviations
-        if config['colors'] is not None:
+        #   Only needs to run for the first iteration of the loop
+        #    since we are overwriting a global configuration
+        if (config['colors'] is not None) and (i > 0):
             for col in config['colors']:
                 trans = config['colors'][col]['transitions']
                 new_trans = []

--- a/QA_LCC.py
+++ b/QA_LCC.py
@@ -118,7 +118,7 @@ if __name__=="__main__":
         # replace transitions with abbreviations
         #   Only needs to run for the first iteration of the loop
         #    since we are overwriting a global configuration
-        if (config['colors'] is not None) and (i > 0):
+        if (config['colors'] is not None) and (i == 0):
             for col in config['colors']:
                 trans = config['colors'][col]['transitions']
                 new_trans = []

--- a/environment.yml
+++ b/environment.yml
@@ -7,5 +7,6 @@ dependencies:
   - numpy=1.26
   - pandas=2.2
   - geopandas-base=0.14
+  - pyogrio=0.2
   - openpyxl=3.1
   - toml=0.10


### PR DESCRIPTION
1. Added `pyogrio` to conda environment.
2. Explicitly set `openpyxl` as the io engine to enable writing to `xlsx` in append mode.
3. When running on multiple cofips only the first iteration should replace the transitions with their abbreviations.

Also for future reference, you can use  `nargs='+'` in argparser to have the `--cfs` argument automatically parse multiple cofips as a list without having to do your own string splitting i.e.:

``` python
parser.add_argument(
        '--cfs',
       nargs='+',
)
```

then call with:
```command line
python QA_LCC.py --cfs cofips1 cofips2 ...